### PR TITLE
Fix test failure

### DIFF
--- a/src/test/java/org/wso2/carbon/codegen/CxfWso2GeneratorTest.java
+++ b/src/test/java/org/wso2/carbon/codegen/CxfWso2GeneratorTest.java
@@ -17,20 +17,22 @@ import org.openapitools.codegen.config.CodegenConfigurator;
  */
 public class CxfWso2GeneratorTest {
 
-  // use this test to launch you code generator in the debugger.
-  // this allows you to easily set break points in MyclientcodegenGenerator.
-  @Test
-  public void launchCodeGenerator() {
-    // to understand how the 'openapi-generator-cli' module is using 'CodegenConfigurator', have a look at the 'Generate' class:
-    // https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Generate.java 
-    final CodegenConfigurator configurator = new CodegenConfigurator()
-              .setGeneratorName("cxf-wso2") // use this codegen library
-              .setInputSpec("../../../modules/openapi-generator/src/test/resources/2_0/petstore.yaml") // sample OpenAPI file
-              // .setInputSpec("https://raw.githubusercontent.com/openapitools/openapi-generator/master/modules/openapi-generator/src/test/resources/2_0/petstore.yaml") // or from the server
-              .setOutputDir("out/cxf-wso2"); // output directory
+    // Use this test to launch you code generator in the debugger.
+    // This allows you to easily set break points in MyclientcodegenGenerator.
+    @Test
+    public void launchCodeGenerator() {
 
-    final ClientOptInput clientOptInput = configurator.toClientOptInput();
-    DefaultGenerator generator = new DefaultGenerator();
-    generator.opts(clientOptInput).generate();
-  }
+        // To understand how the 'openapi-generator-cli' module is using 'CodegenConfigurator', have a look at the 'Generate' class:
+        // https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Generate.java
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("cxf-wso2") // use this codegen library
+                // Commented the below line due the test failure caused.
+                //.setInputSpec("../../../modules/openapi-generator/src/test/resources/2_0/petstore.yaml") // sample OpenAPI file
+                .setInputSpec("https://raw.githubusercontent.com/openapitools/openapi-generator/master/modules/openapi-generator/src/test/resources/2_0/petstore.yaml") // or from the server
+                .setOutputDir("out/cxf-wso2"); // output directory
+
+        final ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+        generator.opts(clientOptInput).generate();
+    }
 }


### PR DESCRIPTION
- Fixed the test failure by using the input spec from the server url.
- Reformat the file.

Fixes: https://github.com/madurangasiriwardena/openapi-generator-cxf-wso2/issues/7