### PR TITLE
Add support for retrieving request and response in the gen code api impl

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,10 @@ mvn clean install
 ```
 
 4. Comment out the plugin added for your API definition before committing to the git.
+
+#### Supported vendor extensions
+| Extension | Purpose | Description                                                                                                                                                   | Example |
+|---|---|---|---|
+| x-gen-include-req-res | Get the HttpServletRequest and the HttpServletResponse objects to the generated code. | Should be added to root of the yaml. If the value is set to `true` then the request and response objects will be available in the generated api impl classes. | x-gen-include-req-res: true |
+
+

--- a/src/main/java/org/wso2/carbon/codegen/CxfWso2Generator.java
+++ b/src/main/java/org/wso2/carbon/codegen/CxfWso2Generator.java
@@ -1,5 +1,6 @@
 package org.wso2.carbon.codegen;
 
+import io.swagger.v3.oas.models.OpenAPI;
 import org.openapitools.codegen.*;
 import io.swagger.models.properties.*;
 import org.openapitools.codegen.languages.JavaJAXRSCXFCDIServerCodegen;
@@ -8,6 +9,9 @@ import java.util.*;
 import java.io.File;
 
 public class CxfWso2Generator extends JavaJAXRSCXFCDIServerCodegen {
+
+  // Property to denote whether to include request/response objects in the generated code.
+  private static final String X_GEN_INCLUDE_REQ_RES = "x-gen-include-req-res";
 
   /**
    * Configures the type of generator.
@@ -73,9 +77,20 @@ public class CxfWso2Generator extends JavaJAXRSCXFCDIServerCodegen {
     if (additionalProperties.containsKey(USE_BEANVALIDATION)) {
       this.setUseBeanValidation(convertPropertyToBoolean(USE_BEANVALIDATION));
     }
-
     writePropertyBack(USE_BEANVALIDATION, useBeanValidation);
 
     supportingFiles.clear(); // Don't need extra files provided by AbstractJAX-RS & Java Codegen
+  }
+
+  @Override
+  public void preprocessOpenAPI(OpenAPI openAPI) {
+    super.preprocessOpenAPI(openAPI);
+
+    if (openAPI != null && openAPI.getExtensions() != null) {
+      Object genIncludeReqRes = openAPI.getExtensions().get(X_GEN_INCLUDE_REQ_RES);
+      if (genIncludeReqRes != null) {
+        additionalProperties.put(X_GEN_INCLUDE_REQ_RES, Boolean.parseBoolean(genIncludeReqRes.toString()));
+      }
+    }
   }
 }

--- a/src/main/resources/cxf-wso2/api.mustache
+++ b/src/main/resources/cxf-wso2/api.mustache
@@ -28,8 +28,15 @@ import java.util.List;
 {{/imports}}
 import {{package}}.{{classname}}Service;
 
+{{#x-gen-include-req-res}}
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+{{/x-gen-include-req-res}}
 import javax.validation.Valid;
 import javax.ws.rs.*;
+{{#x-gen-include-req-res}}
+import javax.ws.rs.core.Context;
+{{/x-gen-include-req-res}}
 import javax.ws.rs.core.Response;
 import io.swagger.annotations.*;
 
@@ -63,9 +70,9 @@ public class {{classname}}  {
     @ApiResponses(value = { {{#responses}}
         @ApiResponse(code = {{{code}}}, message = "{{{message}}}", response = {{{baseType}}}.class{{#containerType}}, responseContainer = "{{{containerType}}}"{{/containerType}}){{#hasMore}},{{/hasMore}}{{/responses}}
     })
-    public Response {{nickname}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) {
+    public Response {{nickname}}({{#x-gen-include-req-res}}@Context HttpServletRequest httpServletRequest, @Context HttpServletResponse httpServletResponse, {{/x-gen-include-req-res}}{{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) {
 
-        return delegate.{{nickname}}({{#allParams}}{{#isFile}}{{paramName}}InputStream, {{paramName}}Detail{{/isFile}}{{^isFile}}{{paramName}}{{/isFile}}{{#hasMore}}, {{/hasMore}} {{/allParams}});
+        return delegate.{{nickname}}({{#x-gen-include-req-res}}httpServletRequest, httpServletResponse, {{/x-gen-include-req-res}}{{#allParams}}{{#isFile}}{{paramName}}InputStream, {{paramName}}Detail{{/isFile}}{{^isFile}}{{paramName}}{{/isFile}}{{#hasMore}}, {{/hasMore}} {{/allParams}});
     }
 
 {{/operation}}

--- a/src/main/resources/cxf-wso2/apiService.mustache
+++ b/src/main/resources/cxf-wso2/apiService.mustache
@@ -26,6 +26,10 @@ import java.io.InputStream;
 import java.util.List;
 {{#imports}}import {{import}};
 {{/imports}}
+{{#x-gen-include-req-res}}
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+{{/x-gen-include-req-res}}
 import javax.ws.rs.core.Response;
 
 {{>generatedAnnotation}}
@@ -33,7 +37,7 @@ import javax.ws.rs.core.Response;
 public interface {{classname}}Service {
   {{#operation}}
 
-      public Response {{nickname}}({{#allParams}}{{>serviceQueryParams}}{{>servicePathParams}}{{>serviceHeaderParams}}{{>serviceBodyParams}}{{>serviceFormParams}}{{#hasMore}}, {{/hasMore}}{{/allParams}});
+      public Response {{nickname}}({{#x-gen-include-req-res}}HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse, {{/x-gen-include-req-res}}{{#allParams}}{{>serviceQueryParams}}{{>servicePathParams}}{{>serviceHeaderParams}}{{>serviceBodyParams}}{{>serviceFormParams}}{{#hasMore}}, {{/hasMore}}{{/allParams}});
   {{/operation}}
 }
 {{/operations}}

--- a/src/main/resources/cxf-wso2/apiServiceImpl.mustache
+++ b/src/main/resources/cxf-wso2/apiServiceImpl.mustache
@@ -21,6 +21,11 @@ package {{package}}.impl;
 import {{package}}.*;
 import {{modelPackage}}.*;
 import java.util.List;
+
+{{#x-gen-include-req-res}}
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+{{/x-gen-include-req-res}}
 import javax.ws.rs.core.Response;
 {{>generatedAnnotation}}
 {{#operations}}
@@ -28,7 +33,7 @@ public class {{classname}}ServiceImpl implements {{classname}}Service {
     {{#operation}}
 
     @Override
-    public Response {{nickname}}({{#allParams}}{{>serviceQueryParams}}{{>servicePathParams}}{{>serviceHeaderParams}}{{>serviceBodyParams}}{{>serviceFormParams}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) {
+    public Response {{nickname}}({{#x-gen-include-req-res}}HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse, {{/x-gen-include-req-res}}{{#allParams}}{{>serviceQueryParams}}{{>servicePathParams}}{{>serviceHeaderParams}}{{>serviceBodyParams}}{{>serviceFormParams}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) {
 
         // do some magic!
         return Response.ok().entity("magic!").build();


### PR DESCRIPTION
This PR adds support for getting the HttpServletRequest and HttpServletResponse objects to the generated api impl classes. This is done via introducing a boolean type vendor extension `x-gen-include-req-res`. The vendor extension needs to be added to the root of the api definition. Setting it to `true` and generating the code will make the request and response objects available as params to the generated API impl methods
 
```
x-gen-include-req-res: true
```